### PR TITLE
fix: correctly setup testcontainers

### DIFF
--- a/backend/beacon/api/src/test/java/com/meemaw/rec/resource/v1/beacon/BeaconBeatResourceProcessingTest.java
+++ b/backend/beacon/api/src/test/java/com/meemaw/rec/resource/v1/beacon/BeaconBeatResourceProcessingTest.java
@@ -9,8 +9,9 @@ import com.meemaw.events.stream.EventsStream;
 import com.meemaw.rec.beacon.resource.v1.BeaconResource;
 import com.meemaw.shared.auth.Organization;
 import com.meemaw.shared.rest.exception.DatabaseException;
-import com.meemaw.test.testconainers.kafka.Kafka;
-import com.meemaw.test.testconainers.pg.Postgres;
+import com.meemaw.test.testconainers.kafka.KafkaTestResource;
+import com.meemaw.test.testconainers.pg.PostgresTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.pgclient.PgPool;
@@ -32,8 +33,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 
-@Postgres
-@Kafka
+@QuarkusTestResource(PostgresTestResource.class)
+@QuarkusTestResource(KafkaTestResource.class)
 @QuarkusTest
 @Tag("integration")
 public class BeaconBeatResourceProcessingTest {

--- a/backend/beacon/api/src/test/java/com/meemaw/rec/resource/v1/beacon/BeaconBeatResourceValidationTest.java
+++ b/backend/beacon/api/src/test/java/com/meemaw/rec/resource/v1/beacon/BeaconBeatResourceValidationTest.java
@@ -5,7 +5,8 @@ import static io.restassured.RestAssured.given;
 
 import com.meemaw.rec.beacon.resource.v1.BeaconResource;
 import com.meemaw.shared.auth.Organization;
-import com.meemaw.test.testconainers.pg.Postgres;
+import com.meemaw.test.testconainers.pg.PostgresTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -17,7 +18,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 
-@Postgres
+@QuarkusTestResource(PostgresTestResource.class)
 @QuarkusTest
 @Tag("integration")
 public class BeaconBeatResourceValidationTest {

--- a/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/elasticsearch/Elasticsearch.java
+++ b/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/elasticsearch/Elasticsearch.java
@@ -8,6 +8,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+/**
+ * If test is annotated with {@link io.quarkus.test.junit.QuarkusTest} use {@link
+ * com.meemaw.test.testconainers.elasticsearch.ElasticsearchTestResource}
+ */
 @Target({TYPE})
 @Retention(RUNTIME)
 @ExtendWith(ElasticsearchExtension.class)

--- a/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/elasticsearch/ElasticsearchExtension.java
+++ b/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/elasticsearch/ElasticsearchExtension.java
@@ -16,9 +16,7 @@ public class ElasticsearchExtension implements BeforeAllCallback {
 
   @Override
   public void beforeAll(ExtensionContext context) {
-    if (!ELASTICSEARCH.isRunning()) {
-      start(ELASTICSEARCH).forEach(System::setProperty);
-    }
+    start(ELASTICSEARCH).forEach(System::setProperty);
   }
 
   public static Map<String, String> start() {
@@ -26,13 +24,14 @@ public class ElasticsearchExtension implements BeforeAllCallback {
   }
 
   public static Map<String, String> start(ElasticsearchTestContainer elasticsearch) {
-    elasticsearch.start();
+    if (!ELASTICSEARCH.isRunning()) {
+      elasticsearch.start();
+    }
     return Collections.emptyMap();
   }
 
   public static void stop() {
     ELASTICSEARCH.stop();
   }
-
 
 }

--- a/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/kafka/Kafka.java
+++ b/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/kafka/Kafka.java
@@ -7,6 +7,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+/**
+ * If test is annotated with {@link io.quarkus.test.junit.QuarkusTest} use {@link
+ * com.meemaw.test.testconainers.kafka.KafkaTestResource}
+ */
 @Target({TYPE})
 @Retention(RUNTIME)
 @ExtendWith(KafkaExtension.class)

--- a/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/kafka/KafkaExtension.java
+++ b/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/kafka/KafkaExtension.java
@@ -2,11 +2,10 @@ package com.meemaw.test.testconainers.kafka;
 
 import java.util.Collections;
 import java.util.Map;
-import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-public class KafkaExtension implements BeforeAllCallback, AfterAllCallback {
+public class KafkaExtension implements BeforeAllCallback {
 
   private static final KafkaTestContainer KAFKA = new KafkaTestContainer();
 
@@ -16,16 +15,7 @@ public class KafkaExtension implements BeforeAllCallback, AfterAllCallback {
 
   @Override
   public void beforeAll(ExtensionContext context) {
-    if (!KAFKA.isRunning()) {
-      start(KAFKA).forEach(System::setProperty);
-    }
-  }
-
-  @Override
-  public void afterAll(ExtensionContext extensionContext) {
-    if (KAFKA.isRunning()) {
-      stop();
-    }
+    start(KAFKA).forEach(System::setProperty);
   }
 
   public static Map<String, String> start() {
@@ -33,7 +23,9 @@ public class KafkaExtension implements BeforeAllCallback, AfterAllCallback {
   }
 
   public static Map<String, String> start(KafkaTestContainer kafka) {
-    kafka.start();
+    if (!KAFKA.isRunning()) {
+      kafka.start();
+    }
     return Collections.singletonMap("kafka.bootstrap.servers", kafka.getBootstrapServers());
   }
 

--- a/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/pg/Postgres.java
+++ b/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/pg/Postgres.java
@@ -8,6 +8,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+/**
+ * If test is annotated with {@link io.quarkus.test.junit.QuarkusTest} use {@link
+ * com.meemaw.test.testconainers.pg.PostgresTestResource}
+ */
 @Target({TYPE})
 @Retention(RUNTIME)
 @ExtendWith(PostgresExtension.class)

--- a/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/pg/PostgresExtension.java
+++ b/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/pg/PostgresExtension.java
@@ -2,7 +2,6 @@ package com.meemaw.test.testconainers.pg;
 
 import java.util.Collections;
 import java.util.Map;
-import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -11,7 +10,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  * <p>
  * USAGE: {@link com.meemaw.test.testconainers.pg.Postgres}
  */
-public class PostgresExtension implements BeforeAllCallback, AfterAllCallback {
+public class PostgresExtension implements BeforeAllCallback {
 
   private static final PostgresTestContainer POSTGRES = PostgresTestContainer.newInstance();
 
@@ -21,19 +20,14 @@ public class PostgresExtension implements BeforeAllCallback, AfterAllCallback {
 
   @Override
   public void beforeAll(ExtensionContext context) {
-    if (!POSTGRES.isRunning()) {
-      start(POSTGRES).forEach(System::setProperty);
-    }
-  }
+    System.out.println("beforeAll");
+    start(POSTGRES).forEach(System::setProperty);
+    System.out.println(System.getProperties());
 
-  @Override
-  public void afterAll(ExtensionContext extensionContext) {
-    if (POSTGRES.isRunning()) {
-      stop();
-    }
   }
 
   public static void stop() {
+    System.out.println("STOPPING!");
     POSTGRES.stop();
   }
 
@@ -42,8 +36,11 @@ public class PostgresExtension implements BeforeAllCallback, AfterAllCallback {
   }
 
   public static Map<String, String> start(PostgresTestContainer postgres) {
-    postgres.start();
-    postgres.applyMigrations();
+    if (!POSTGRES.isRunning()) {
+      System.out.println("STARTING");
+      postgres.start();
+      postgres.applyMigrations();
+    }
     return Collections.singletonMap("quarkus.datasource.url", postgres.getDatasourceURL());
   }
 

--- a/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/pg/PostgresExtension.java
+++ b/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/pg/PostgresExtension.java
@@ -20,14 +20,10 @@ public class PostgresExtension implements BeforeAllCallback {
 
   @Override
   public void beforeAll(ExtensionContext context) {
-    System.out.println("beforeAll");
     start(POSTGRES).forEach(System::setProperty);
-    System.out.println(System.getProperties());
-
   }
 
   public static void stop() {
-    System.out.println("STOPPING!");
     POSTGRES.stop();
   }
 
@@ -37,7 +33,6 @@ public class PostgresExtension implements BeforeAllCallback {
 
   public static Map<String, String> start(PostgresTestContainer postgres) {
     if (!POSTGRES.isRunning()) {
-      System.out.println("STARTING");
       postgres.start();
       postgres.applyMigrations();
     }

--- a/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/service/AuthApiTestResource.java
+++ b/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/service/AuthApiTestResource.java
@@ -3,7 +3,13 @@ package com.meemaw.test.testconainers.service;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import java.util.Map;
 
-public class AuthApiResource implements QuarkusTestResourceLifecycleManager {
+/**
+ * Quarkus compatible test resource.
+ *
+ * <p>
+ * USAGE: @QuarkusTestResource(AuthApiTestResource.class)
+ */
+public class AuthApiTestResource implements QuarkusTestResourceLifecycleManager {
 
   private static final AuthApiTestContainer AUTH_API = AuthApiTestContainer.newInstance();
 


### PR DESCRIPTION
If a `QuarkusTest` without testcontainer annotation was executed prior tests with testcontainer annotation, then quarkus server was created without being linked to those containers that were later created.

Luckily, Quarkus comes with a `QuarkusTestResource` that should handle this for us.