### PR TITLE
chore: add only required modules to docker

### DIFF
--- a/backend/beacon/api/docker/Dockerfile.jvm
+++ b/backend/beacon/api/docker/Dockerfile.jvm
@@ -1,7 +1,16 @@
 FROM gradle:6.4.1-jdk14 as build
 
-COPY . /backend
 WORKDIR /backend
+
+COPY gradle.properties settings.gradle build.gradle /backend/
+COPY beacon/api/ /backend/beacon/api/
+COPY auth/auth-model/ /backend/auth/auth-model/
+COPY auth/auth-cookie/ /backend/auth/auth-cookie/
+COPY events/model/ /backend/events/model/
+COPY session/session-model/ /backend/session/session-model/
+COPY session/session-api-contracts/ /backend/session/session-api-contracts/
+COPY shared/rest/ /backend/shared/rest/
+COPY shared/rest-api/ /backend/shared/rest-api/
 
 RUN gradle beacon:api:quarkusBuild --uber-jar
 

--- a/backend/events/search-indexer/docker/Dockerfile.jvm
+++ b/backend/events/search-indexer/docker/Dockerfile.jvm
@@ -1,8 +1,8 @@
 FROM gradle:6.4.1-jdk14 as build
 
 COPY build.gradle lombok.config gradle.properties settings.gradle /backend/
-COPY shared /backend/shared
-COPY events /backend/events
+COPY shared/rest-elasticsearch /backend/shared/rest-elasticsearch
+COPY events/model /backend/events/model
 WORKDIR /backend
 
 RUN gradle --no-daemon events:search-indexer:jar

--- a/backend/session/session-api/build.gradle
+++ b/backend/session/session-api/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation 'io.quarkus:quarkus-hibernate-validator'
     implementation 'io.quarkus:quarkus-reactive-pg-client'
     implementation 'io.quarkus:quarkus-rest-client'
-    implementation project(":events:model")
+    implementation project(':events:model')
     implementation project(':auth:auth-sidecar')
     implementation project(':session:session-model')
     implementation project(':session:session-api-contracts')

--- a/backend/session/session-api/docker/Dockerfile.jvm
+++ b/backend/session/session-api/docker/Dockerfile.jvm
@@ -1,7 +1,19 @@
 FROM gradle:6.4.1-jdk14 as build
 
-COPY . /backend
 WORKDIR /backend
+
+COPY gradle.properties settings.gradle build.gradle /backend/
+COPY session/session-model/ /backend/session/session-model/
+COPY session/session-api-contracts/ /backend/session/session-api-contracts/
+COPY session/session-api/ /backend/session/session-api/
+COPY auth/auth-model/ /backend/auth/auth-model/
+COPY auth/auth-cookie/ /backend/auth/auth-cookie/
+COPY auth/auth-sidecar/ /backend/auth/auth-sidecar/
+COPY auth/auth-api-contracts/ /backend/auth/auth-api-contracts/
+COPY events/model/ /backend/events/model/
+COPY shared/rest/ /backend/shared/rest/
+COPY shared/rest-elasticsearch/ /backend/shared/rest-elasticsearch/
+COPY shared/rest-api/ /backend/shared/rest-api/
 
 RUN gradle session:session-api:quarkusBuild --uber-jar
 

--- a/frontend/app/docker/Dockerfile
+++ b/frontend/app/docker/Dockerfile
@@ -8,10 +8,18 @@ ENV NEXT_PUBLIC_AUTH_API_BASE_URL=$auth_api_client_base_url
 ARG auth_api_server_base_url=http://localhost:8080
 ENV AUTH_API_BASE_URL=$auth_api_server_base_url
 
-COPY . /src
-
+COPY package.json yarn.lock tsconfig.json /src/
+COPY frontend/app/package.json /src/frontend/app/package.json
+COPY frontend/shared/types/package.json /src/frontend/shared/types/package.json
+COPY frontend/shared/testing/package.json /src/frontend/shared/testing/package.json
+COPY frontend/shared/storybook/package.json /src/frontend/shared/storybook/package.json
 RUN yarn install --frozen-lockfile
+
+COPY frontend/app/ /src/frontend/app/
+COPY frontend/shared/ /src/frontend/shared/
+
 RUN yarn workspace @insight/app build
+RUN yarn install --frozen-lockfile --production --ignore-scripts --prefer-offline
 
 FROM node:14-alpine
 

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -52,6 +52,8 @@
     "@types/react": "16.9.35",
     "@types/react-dom": "16.9.8",
     "@types/uuid": "8.0.0",
+    "@types/styletron-engine-atomic": "1.1.0",
+    "@types/styletron-react": "5.0.2",
     "uuid": "8.1.0"
   }
 }


### PR DESCRIPTION
The improvement should be most noticable for `frontend:app` where we will re-install dependencies only if some of them actually change. (so this will be cached most of the time)