### PR TITLE
fix: cookie tld

### DIFF
--- a/.github/workflows/backend:test.yml
+++ b/.github/workflows/backend:test.yml
@@ -26,6 +26,11 @@ jobs:
           wrapper-directory: backend
         env:
           DOCKER_BUILDKIT: 1
+      - uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: testReport
+          build-root-directory: backend
+          wrapper-directory: backend
       - uses: actions/upload-artifact@v2
         if: always()
         with:

--- a/.github/workflows/backend:test.yml
+++ b/.github/workflows/backend:test.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: 14
       - uses: eskatos/gradle-command-action@v1
         with:
-          arguments: test --continue jacocoTestReport
+          arguments: test --continue
           build-root-directory: backend
           wrapper-directory: backend
         env:

--- a/.github/workflows/backend:test.yml
+++ b/.github/workflows/backend:test.yml
@@ -26,17 +26,11 @@ jobs:
           wrapper-directory: backend
         env:
           DOCKER_BUILDKIT: 1
-      - uses: eskatos/gradle-command-action@v1
-        if: failure()
-        with:
-          arguments: testReport
-          build-root-directory: backend
-          wrapper-directory: backend
       - uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: test-report-allTests
-          path: backend/build/reports/allTests
+          name: test-reports
+          path: backend/**/build/reports/tests/**
       - uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/backend:test.yml
+++ b/.github/workflows/backend:test.yml
@@ -27,6 +27,7 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
       - uses: eskatos/gradle-command-action@v1
+        if: failure()
         with:
           arguments: testReport
           build-root-directory: backend
@@ -35,12 +36,7 @@ jobs:
         if: always()
         with:
           name: test-report-allTests
-          path: backend/build/reports/allTests # seems to not be generated
-      - uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: test-reports
-          path: backend/**/build/reports/tests/**
+          path: backend/build/reports/allTests
       - uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/backend:test.yml
+++ b/.github/workflows/backend:test.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: 14
       - uses: eskatos/gradle-command-action@v1
         with:
-          arguments: test --continue
+          arguments: test --continue jacocoTestReport
           build-root-directory: backend
           wrapper-directory: backend
         env:
@@ -29,8 +29,13 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: always()
         with:
+          name: test-report-allTests
+          path: backend/build/reports/allTests # seems to not be generated
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
           name: test-reports
-          path: backend/build/reports/allTests
+          path: backend/**/build/reports/tests/**
       - uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/org/invite/resource/v1/InviteResourceImpl.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/org/invite/resource/v1/InviteResourceImpl.java
@@ -16,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 public class InviteResourceImpl implements InviteResource {
 
   @Inject InsightPrincipal principal;
-
   @Inject InviteService inviteService;
 
   @Override

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/password/resource/v1/PasswordResourceImpl.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/password/resource/v1/PasswordResourceImpl.java
@@ -5,17 +5,20 @@ import com.meemaw.auth.password.model.dto.PasswordResetRequestDTO;
 import com.meemaw.auth.password.service.PasswordService;
 import com.meemaw.auth.sso.model.SsoSession;
 import com.meemaw.auth.sso.service.SsoService;
+import com.meemaw.shared.context.RequestUtils;
 import com.meemaw.shared.rest.response.DataResponse;
+import io.vertx.core.http.HttpServerRequest;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 public class PasswordResourceImpl implements PasswordResource {
 
   @Inject PasswordService passwordService;
-
   @Inject SsoService ssoService;
+  @Context HttpServerRequest request;
 
   @Override
   public CompletionStage<Response> forgot(PasswordForgotRequestDTO passwordForgotRequestDTO) {
@@ -25,18 +28,21 @@ public class PasswordResourceImpl implements PasswordResource {
   }
 
   @Override
-  public CompletionStage<Response> reset(PasswordResetRequestDTO passwordResetRequestDTO) {
+  public CompletionStage<Response> reset(PasswordResetRequestDTO payload) {
     return passwordService
-        .reset(passwordResetRequestDTO)
+        .reset(payload)
         .thenCompose(
             x -> {
-              String email = passwordResetRequestDTO.getEmail();
-              String password = passwordResetRequestDTO.getPassword();
+              String email = payload.getEmail();
+              String password = payload.getPassword();
+              String cookieDomain = RequestUtils.parseCookieDomain(request.absoluteURI());
               return ssoService
                   .login(email, password)
                   .thenApply(
                       sessionId ->
-                          Response.noContent().cookie(SsoSession.cookie(sessionId)).build());
+                          Response.noContent()
+                              .cookie(SsoSession.cookie(sessionId, cookieDomain))
+                              .build());
             });
   }
 

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/password/resource/v1/PasswordResourceImpl.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/password/resource/v1/PasswordResourceImpl.java
@@ -29,13 +29,13 @@ public class PasswordResourceImpl implements PasswordResource {
 
   @Override
   public CompletionStage<Response> reset(PasswordResetRequestDTO payload) {
+    String cookieDomain = RequestUtils.parseCookieDomain(request.absoluteURI());
     return passwordService
         .reset(payload)
         .thenCompose(
             x -> {
               String email = payload.getEmail();
               String password = payload.getPassword();
-              String cookieDomain = RequestUtils.parseCookieDomain(request.absoluteURI());
               return ssoService
                   .login(email, password)
                   .thenApply(

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/signup/resource/v1/SignupResourceImpl.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/signup/resource/v1/SignupResourceImpl.java
@@ -31,13 +31,13 @@ public class SignupResourceImpl implements SignupResource {
 
   @Override
   public CompletionStage<Response> signupComplete(SignupRequestCompleteDTO payload) {
+    String cookieDomain = RequestUtils.parseCookieDomain(request.absoluteURI());
     return signupService
         .complete(payload)
         .thenCompose(
             x -> {
               String email = payload.getEmail();
               String password = payload.getPassword();
-              String cookieDomain = RequestUtils.parseCookieDomain(request.absoluteURI());
               return ssoService
                   .login(email, password)
                   .thenApply(

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/signup/resource/v1/SignupResourceImpl.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/signup/resource/v1/SignupResourceImpl.java
@@ -4,17 +4,20 @@ import com.meemaw.auth.signup.model.dto.SignupRequestCompleteDTO;
 import com.meemaw.auth.signup.service.SignupService;
 import com.meemaw.auth.sso.model.SsoSession;
 import com.meemaw.auth.sso.service.SsoService;
+import com.meemaw.shared.context.RequestUtils;
 import com.meemaw.shared.rest.response.DataResponse;
+import io.vertx.core.http.HttpServerRequest;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 public class SignupResourceImpl implements SignupResource {
 
   @Inject SignupService signupService;
-
   @Inject SsoService ssoService;
+  @Context HttpServerRequest request;
 
   @Override
   public CompletionStage<Response> signup(String email) {
@@ -27,18 +30,21 @@ public class SignupResourceImpl implements SignupResource {
   }
 
   @Override
-  public CompletionStage<Response> signupComplete(SignupRequestCompleteDTO req) {
+  public CompletionStage<Response> signupComplete(SignupRequestCompleteDTO payload) {
     return signupService
-        .complete(req)
+        .complete(payload)
         .thenCompose(
             x -> {
-              String email = req.getEmail();
-              String password = req.getPassword();
+              String email = payload.getEmail();
+              String password = payload.getPassword();
+              String cookieDomain = RequestUtils.parseCookieDomain(request.absoluteURI());
               return ssoService
                   .login(email, password)
                   .thenApply(
                       sessionId ->
-                          Response.noContent().cookie(SsoSession.cookie(sessionId)).build());
+                          Response.noContent()
+                              .cookie(SsoSession.cookie(sessionId, cookieDomain))
+                              .build());
             });
   }
 }

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/cookie/CookieAuthDynamicFeature.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/cookie/CookieAuthDynamicFeature.java
@@ -1,6 +1,5 @@
-package com.meemaw.auth.sso.core;
+package com.meemaw.auth.sso.cookie;
 
-import com.meemaw.auth.sso.cookie.AbstractCookieAuthDynamicFeature;
 import com.meemaw.auth.sso.datasource.SsoDatasource;
 import com.meemaw.auth.sso.model.SsoUser;
 import java.util.Optional;

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/model/SsoSocialLogin.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/model/SsoSocialLogin.java
@@ -9,5 +9,5 @@ public class SsoSocialLogin {
 
   String sessionId;
   String Location;
-
+  String cookieDomain;
 }

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/resource/v1/SsoResourceImpl.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/resource/v1/SsoResourceImpl.java
@@ -23,15 +23,12 @@ public class SsoResourceImpl implements SsoResource {
 
   @Override
   public CompletionStage<Response> login(String email, String password) {
+    String cookieDomain = RequestUtils.parseCookieDomain(request.absoluteURI());
     return ssoService
         .login(email, password)
         .thenApply(
-            sessionId -> {
-              String cookieDomain = RequestUtils.parseCookieDomain(request.absoluteURI());
-              return Response.noContent()
-                  .cookie(SsoSession.cookie(sessionId, cookieDomain))
-                  .build();
-            });
+            sessionId ->
+                Response.noContent().cookie(SsoSession.cookie(sessionId, cookieDomain)).build());
   }
 
   @Override

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/resource/v1/SsoResourceImpl.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/resource/v1/SsoResourceImpl.java
@@ -33,6 +33,7 @@ public class SsoResourceImpl implements SsoResource {
 
   @Override
   public CompletionStage<Response> logout(String sessionId) {
+    String cookieDomain = RequestUtils.parseCookieDomain(request.absoluteURI());
     return ssoService
         .logout(sessionId)
         .thenApply(
@@ -42,21 +43,19 @@ public class SsoResourceImpl implements SsoResource {
                       ? Response.noContent()
                       : DataResponse.error(Boom.badRequest().message("Session does not exist"))
                           .builder();
-
-              String cookieDomain = RequestUtils.parseCookieDomain(request.absoluteURI());
               return builder.cookie(SsoSession.clearCookie(cookieDomain)).build();
             });
   }
 
   @Override
   public CompletionStage<Response> session(String sessionId) {
+    String cookieDomain = RequestUtils.parseCookieDomain(request.absoluteURI());
     return ssoService
         .findSession(sessionId)
         .thenApply(
             maybeUser -> {
               if (maybeUser.isEmpty()) {
                 log.info("sessionId={} not found", sessionId);
-                String cookieDomain = RequestUtils.parseCookieDomain(request.absoluteURI());
                 return Response.noContent().cookie(SsoSession.clearCookie(cookieDomain)).build();
               }
               return DataResponse.ok(maybeUser.get());

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/resource/v1/google/SsoGoogleResourceImpl.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/resource/v1/google/SsoGoogleResourceImpl.java
@@ -49,9 +49,11 @@ public class SsoGoogleResourceImpl implements SsoGoogleResource {
             ssoSocialLogin -> {
               String Location = ssoSocialLogin.getLocation();
               String SessionId = ssoSocialLogin.getSessionId();
+              String cookieDomain = ssoSocialLogin.getCookieDomain();
+
               return Response.status(Status.FOUND)
                   .header("Location", Location)
-                  .cookie(SsoSession.cookie(SessionId))
+                  .cookie(SsoSession.cookie(SessionId, cookieDomain))
                   .build();
             });
   }

--- a/backend/auth/auth-api/src/test/java/com/meemaw/auth/sso/resource/v1/SsoResourceImplTest.java
+++ b/backend/auth/auth-api/src/test/java/com/meemaw/auth/sso/resource/v1/SsoResourceImplTest.java
@@ -29,9 +29,7 @@ import org.junit.jupiter.api.Test;
 public class SsoResourceImplTest {
 
   @Inject MockMailbox mailbox;
-
   @Inject UserDatasource userDatasource;
-
   @Inject ObjectMapper objectMapper;
 
   @BeforeEach

--- a/backend/auth/auth-model/src/main/java/com/meemaw/auth/sso/model/SsoSession.java
+++ b/backend/auth/auth-model/src/main/java/com/meemaw/auth/sso/model/SsoSession.java
@@ -19,16 +19,16 @@ public class SsoSession {
   // Number of characters in cookie
   public static final int SIZE = 50;
 
-  public static NewCookie cookie(String sessionId) {
-    return newCookie(sessionId, TTL);
+  public static NewCookie cookie(String sessionId, String domain) {
+    return newCookie(sessionId, domain, TTL);
   }
 
-  public static NewCookie clearCookie() {
-    return newCookie(null, 0);
+  public static NewCookie clearCookie(String domain) {
+    return newCookie(null, domain, 0);
   }
 
-  private static NewCookie newCookie(String sessionId, int maxAge) {
-    return new NewCookie(COOKIE_NAME, sessionId, COOKIE_PATH, null, null, maxAge, false);
+  private static NewCookie newCookie(String sessionId, String domain, int maxAge) {
+    return new NewCookie(COOKIE_NAME, sessionId, COOKIE_PATH, domain, null, maxAge, false);
   }
 
   public static String newIdentifier() {

--- a/backend/auth/auth-model/src/test/java/com/meemaw/auth/sso/model/SsoSessionTest.java
+++ b/backend/auth/auth-model/src/test/java/com/meemaw/auth/sso/model/SsoSessionTest.java
@@ -14,6 +14,6 @@ public class SsoSessionTest {
   @Test
   public void ssoSessionCookie_should_be_correctly_named() {
     String sessionId = SsoSession.newIdentifier();
-    assertEquals(SsoSession.COOKIE_NAME, SsoSession.cookie(sessionId).getName());
+    assertEquals(SsoSession.COOKIE_NAME, SsoSession.cookie(sessionId, null).getName());
   }
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -59,10 +59,13 @@ subprojects {
     }
 
     test {
-        finalizedBy(tasks.jacocoTestReport, rootProject.tasks.testReport)
+        finalizedBy tasks.jacocoTestReport
+        finalizedBy rootProject.tasks.testReport
         systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
         testLogging.showStandardStreams = true
     }
+
+    test.finalizedBy()
 
     checkstyle {
         toolVersion = '8.32'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -64,9 +64,7 @@ subprojects {
         systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
         testLogging.showStandardStreams = true
     }
-
-    test.finalizedBy()
-
+    
     checkstyle {
         toolVersion = '8.32'
         configFile = rootProject.file('config/checkstyle/.checkstyle.xml')

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -17,6 +17,12 @@ allprojects {
     version '1.0'
 }
 
+task testReport(type: TestReport) {
+    destinationDir = file("$buildDir/reports/allTests")
+    // Include the results from the `test` task in all subprojects
+    reportOn subprojects.collect { it.tasks.withType(Test) }
+}
+
 subprojects {
     apply plugin: 'java'
     apply plugin: 'jacoco'
@@ -52,7 +58,7 @@ subprojects {
     }
 
     test {
-        finalizedBy tasks.jacocoTestReport
+        finalizedBy(tasks.jacocoTestReport, rootProject.tasks.testReport)
         systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
         testLogging.showStandardStreams = true
     }
@@ -84,11 +90,3 @@ tasks.withType(Checkstyle) {
         html.enabled false
     }
 }
-
-task testReport(type: TestReport) {
-    destinationDir = file("$buildDir/reports/allTests")
-    // Include the results from the `test` task in all subprojects
-    reportOn subprojects.collect { it.tasks.withType(Test) }
-}
-
-tasks.test.finalizedBy rootProject.tasks.testReport

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -17,13 +17,6 @@ allprojects {
     version '1.0'
 }
 
-task testReport(type: TestReport) {
-    destinationDir = file("$buildDir/reports/allTests")
-    // Include the results from the `test` task in all subprojects
-    reportOn subprojects.collect { it.tasks.withType(Test) }
-}
-
-
 subprojects {
     apply plugin: 'java'
     apply plugin: 'jacoco'
@@ -60,11 +53,10 @@ subprojects {
 
     test {
         finalizedBy tasks.jacocoTestReport
-        finalizedBy rootProject.tasks.testReport
         systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
         testLogging.showStandardStreams = true
     }
-    
+
     checkstyle {
         toolVersion = '8.32'
         configFile = rootProject.file('config/checkstyle/.checkstyle.xml')
@@ -92,3 +84,11 @@ tasks.withType(Checkstyle) {
         html.enabled false
     }
 }
+
+task testReport(type: TestReport) {
+    destinationDir = file("$buildDir/reports/allTests")
+    // Include the results from the `test` task in all subprojects
+    reportOn subprojects.collect { it.tasks.withType(Test) }
+}
+
+tasks.test.finalizedBy rootProject.tasks.testReport

--- a/backend/shared/rest-api/src/main/java/com/meemaw/shared/context/RequestUtils.java
+++ b/backend/shared/rest-api/src/main/java/com/meemaw/shared/context/RequestUtils.java
@@ -9,6 +9,8 @@ import javax.ws.rs.core.UriInfo;
 
 public final class RequestUtils {
 
+  private static final int DOMAIN_MIN_PARTS = 2;
+
   private RequestUtils() {}
 
   /**
@@ -78,17 +80,16 @@ public final class RequestUtils {
    *
    * @param url associated with the http request
    * @return Optional String top level domain
-   * @throws com.meemaw.shared.rest.exception.BoomException if malformed URL
    */
   public static Optional<String> parseTLD(String url) {
     try {
       String[] parts = new URL(url).getHost().split("\\.");
-      if (parts.length == 1) {
+      if (parts.length < DOMAIN_MIN_PARTS) {
         return Optional.empty();
       }
       return Optional.of(String.join(".", parts[parts.length - 2], parts[parts.length - 1]));
     } catch (MalformedURLException e) {
-      throw Boom.badRequest().message(e.getMessage()).exception(e);
+      return Optional.empty();
     }
   }
 
@@ -97,7 +98,6 @@ public final class RequestUtils {
    *
    * @param url associated with the http request
    * @return String cookie domain if present else null
-   * @throws com.meemaw.shared.rest.exception.BoomException if malformed URL
    */
   public static String parseCookieDomain(String url) {
     return parseTLD(url).orElse(null);

--- a/backend/shared/rest-api/src/test/java/com/meemaw/shared/context/RequestUtilsTest.java
+++ b/backend/shared/rest-api/src/test/java/com/meemaw/shared/context/RequestUtilsTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 public class RequestUtilsTest {
@@ -15,5 +16,13 @@ public class RequestUtilsTest {
 
     URL withNoPort = new URL("https://google.com/login?dest=%2F");
     assertEquals("https://google.com", RequestUtils.parseBaseURL(withNoPort));
+  }
+
+  @Test
+  public void should_parse_tld() {
+    assertEquals(Optional.of("insight.io"), RequestUtils.parseTLD("http://app.insight.io"));
+    assertEquals(Optional.of("insight.io"), RequestUtils.parseTLD("https://app.insight.io"));
+    assertEquals(Optional.of("insight.io"), RequestUtils.parseTLD("https://insight.io"));
+    assertEquals(Optional.empty(), RequestUtils.parseTLD("http://localhost:3000"));
   }
 }

--- a/backend/shared/rest-api/src/test/java/com/meemaw/shared/context/RequestUtilsTest.java
+++ b/backend/shared/rest-api/src/test/java/com/meemaw/shared/context/RequestUtilsTest.java
@@ -23,6 +23,8 @@ public class RequestUtilsTest {
     assertEquals(Optional.of("insight.io"), RequestUtils.parseTLD("http://app.insight.io"));
     assertEquals(Optional.of("insight.io"), RequestUtils.parseTLD("https://app.insight.io"));
     assertEquals(Optional.of("insight.io"), RequestUtils.parseTLD("https://insight.io"));
+    assertEquals(Optional.empty(), RequestUtils.parseTLD("app"));
     assertEquals(Optional.empty(), RequestUtils.parseTLD("http://localhost:3000"));
+    assertEquals(Optional.empty(), RequestUtils.parseTLD(""));
   }
 }


### PR DESCRIPTION
Cookies have to have a `domain` specified when not used on localhost. To enable cookies in "prod" always associate cookie with the TLD (top level domain) of the request. This makes the following setup possible:

- Backend on: services.insight.io
- App on: app.insight.io

On login cookie will be set for the `insight.io` domain and available for all subdomainds.

Tested locally with the following `/etc/hosts` setup:
```
127.0.0.1 app.insight.io
127.0.0.1 services.insight.io
127.0.0.1 try.insight.io
```